### PR TITLE
Added Comment Support

### DIFF
--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -21,6 +21,7 @@ pub struct Token {
 #[derive(Logos, Debug, PartialEq, Clone)]
 #[logos(error = LexError)]
 #[logos(extras = (usize,usize))]
+#[logos(skip r"[ \t\r\f]+")]
 pub enum TokenType {
     // Datatypes
     #[token("s8")]

--- a/compiler/lexer/tests/comments_test.rs
+++ b/compiler/lexer/tests/comments_test.rs
@@ -68,7 +68,9 @@ fn test_comment() {
         },
     ];
 
-    let tokens: Vec<_> = lex(input).filter_map(|result| result.ok()).collect();
-
+    let tokens: Vec<Token> = lex(input)
+        .filter_map(|result| result.ok())
+        .collect();
+    
     assert_eq!(tokens, expected_tokens);
 }

--- a/compiler/lexer/tests/datatypes_test.rs
+++ b/compiler/lexer/tests/datatypes_test.rs
@@ -112,7 +112,9 @@ fn test_all_datatypes_no_spaces() {
         },
     ];
 
-    let tokens: Vec<_> = lex(input).filter_map(|result| result.ok()).collect();
-
+    let tokens: Vec<Token> = lex(input)
+        .filter_map(|result| result.ok()) 
+        .collect();
+    
     assert_eq!(tokens, expected_tokens);
 }

--- a/compiler/lexer/tests/locations_test.rs
+++ b/compiler/lexer/tests/locations_test.rs
@@ -52,7 +52,7 @@ fn test_location() {
     ];
 
     let tokens: Vec<Token> = lex(input)
-        .filter_map(|result| result.ok()) // keep only Ok tokens
+        .filter_map(|result| result.ok()) 
         .collect();
 
     assert_eq!(tokens, expected_tokens);


### PR DESCRIPTION
This version of the lexer now supports single line comments.

I added a Token::Comment(), which has a String. This String saves the entire line - the entire comment.