### PR TITLE
Fix FreeBSD runner issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           run: |
             set -e # Exit immediately if command fails
             cd compiler
-            cargo test --workspace --jobs 2 # This is done to preven OOM errors: https://github.com/Randware/Wasome/issues/33
+            cargo test --workspace --jobs 2 # This is done to prevent OOM errors: https://github.com/Randware/Wasome/issues/33
 
       - name: Save Result
         if: always()


### PR DESCRIPTION
## Fix for #33 

Introduces a fix for issue #33 by limiting cargo jobs for FreeBSD and failing immediately if an errors occurs.  
  
FreeBSD is probably the only platform that is effected. GitHub actions does not support FreeBSD natively so it runs on a VM inside an Ubuntu machine and has limited resources. 