### PR TITLE
Prevent OOM inside io crate

### DIFF
--- a/compiler/io/src/wasome_loader.rs
+++ b/compiler/io/src/wasome_loader.rs
@@ -173,7 +173,7 @@ fn dir_entry_has_file_type_condition<Condition: FnMut(FileType) -> bool>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs::File, io::Write};
+    use std::{fs::File, io::Write, u32};
     use tempfile::tempdir;
 
     #[test]
@@ -223,6 +223,19 @@ mod tests {
 
         // USE THE GETTER! It is public, so use it.
         assert_eq!(&source_file, "Hello World");
+    }
+
+    #[test]
+    fn test_load_non_existent_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("ghost.waso");
+
+        let result = WasomeLoader::load(&file_path);
+
+        assert!(result.is_err(), "Should return an error for missing files");
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]


### PR DESCRIPTION
This fixes a potential OOM that could occur if we try to load a 10gb+ file. 
Since our guard if statement happens after loading the file it would not prevent OOM errors.
This eliminates this by looking at the file size first and only loading it afterwards.