### PR TITLE
Fixed a bug that caused file not founds when syntax checking

### DIFF
--- a/compiler/driver/src/source_collector.rs
+++ b/compiler/driver/src/source_collector.rs
@@ -41,7 +41,7 @@ pub(crate) fn collect_program(
             .map(|project| {
                 Result::<_, CollectionError>::Ok((
                     project.name().to_string(),
-                    collect_dir(to_collect.path().join(project.name()), load_from)?,
+                    collect_dir(to_collect.path().join(project.path()), load_from)?,
                 ))
             })
             .collect::<Result<_, _>>()?,


### PR DESCRIPTION
This fixes the following when syntax checking:

```
Info  Checking project at /home/***/tests/fixtures/invalid

Error  IO Error: No such file or directory (os error 2) E4001

Error  Check was not successful
```