### PR TITLE
Split up ProgramInformation

### DIFF
--- a/cli/src/execute.rs
+++ b/cli/src/execute.rs
@@ -1,6 +1,6 @@
-use std::path;
-
+use driver::program_information::LoadInformation;
 use error::diagnostic::{Diagnostic, Level};
+use std::path;
 
 use crate::{
     command::{BuildArgs, CheckArgs, Cli, Command, FmtArgs, NewArgs},

--- a/cli/src/workspace.rs
+++ b/cli/src/workspace.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use driver::program_information::ProgramInformation;
+use driver::program_information::{ConcreteBinaryProgramInformation, ConcreteLoadBinaryProgramInformation, ConcreteLoadInformation};
 use source::SourceMap;
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
 
 pub struct Workspace {
     pub source: SourceMap,
-    pub info: ProgramInformation,
+    pub info: ConcreteLoadBinaryProgramInformation,
 }
 
 impl Workspace {
@@ -26,7 +26,7 @@ impl Workspace {
 
         // We wrap everything past here in a closure so we can catch ManifestError
         // and attach the SourceMap to it before returning CliError
-        let mut build_workspace = || -> Result<ProgramInformation, ManifestError> {
+        let mut build_workspace = || -> Result<ConcreteLoadBinaryProgramInformation, ManifestError> {
             let file_id = source.load_file(manifest::MANIFEST_FILE)?;
             let content = source.get_file(&file_id).unwrap().content();
 
@@ -43,12 +43,14 @@ impl Workspace {
                 PathBuf::from("."),
             ));
 
-            let info = ProgramInformation::new(
+            let info = ConcreteLoadBinaryProgramInformation::new(
+                ConcreteLoadInformation::new(
                 manifest.project.name.clone(),
                 root.clone(),
-                projects,
+                projects),
+                ConcreteBinaryProgramInformation::new(
                 manifest.project.name.clone(),
-                entry_file,
+                entry_file)
             );
 
             info.ok_or_else(|| ManifestError::NoEntry(manifest.project.name.clone()))
@@ -93,6 +95,7 @@ fn find_entry_file(root: &Path, manifest: &Manifest) -> Result<PathBuf, Manifest
 mod tests {
     use super::*;
     use crate::{manifest::MANIFEST_FILE, template::Template};
+    use driver::program_information::{BinaryProgramInformation, LoadInformation};
     use std::fs;
     use tempfile::tempdir;
 

--- a/compiler/driver/src/lib.rs
+++ b/compiler/driver/src/lib.rs
@@ -1,11 +1,11 @@
 use crate::error::DriverError;
 use crate::parser_driver::generate_untyped_ast;
-use crate::pipeline::{from_func, from_infallible_func, Pipeline};
-use crate::program_information::ProgramInformation;
+use crate::pipeline::{Pipeline, from_func, from_infallible_func};
+use crate::program_information::{LoadBinaryProgramInformation, LoadInformation};
 use crate::source_collector::{CollectionError, collect_program};
 use crate::source_element::WasomeProgram;
 use ::error::diagnostic::Diagnostic;
-use ast::{TypedAST, UntypedAST, AST};
+use ast::{AST, TypedAST, UntypedAST};
 use io::FullIO;
 use semantic_analyzer::analyze;
 use source::SourceMap;
@@ -23,7 +23,7 @@ pub mod source_element;
 ///
 /// If an error is found, it is returned
 pub fn syntax_check<'a, IO: FullIO>(
-    to_check: &'a ProgramInformation,
+    to_check: &'a impl LoadBinaryProgramInformation,
     source_map: &'a mut SourceMap<IO>,
 ) -> Result<(), Diagnostic> {
     syntax_check_pipeline().process((to_check, source_map))
@@ -35,15 +35,15 @@ pub fn syntax_check<'a, IO: FullIO>(
 /// 3. Performs semantic analysis
 /// 4. Voids all errors
 #[must_use]
-pub fn syntax_check_pipeline<IO: FullIO>()
--> impl for<'a> Pipeline<(&'a ProgramInformation, &'a mut SourceMap<IO>), Diagnostic, Output = ()> {
+pub fn syntax_check_pipeline<IO: FullIO, T: LoadBinaryProgramInformation>()
+-> impl for<'a> Pipeline<(&'a T, &'a mut SourceMap<IO>), Diagnostic, Output = ()> {
     let from: fn((_, &mut SourceMap<IO>)) = |_| ();
     typed_ast_pipeline().then(from_infallible_func::<_, (), (), _>(from))
 }
 
 #[must_use]
-pub(crate) fn load_parse_pipeline<IO: FullIO>() -> impl for<'a> Pipeline<
-    (&'a ProgramInformation, &'a mut SourceMap<IO>),
+pub(crate) fn load_parse_pipeline<IO: FullIO, T: LoadInformation>() -> impl for<'a> Pipeline<
+    (&'a T, &'a mut SourceMap<IO>),
     Diagnostic,
     Output = (AST<UntypedAST>, &'a mut SourceMap<IO>),
 > {
@@ -53,8 +53,9 @@ pub(crate) fn load_parse_pipeline<IO: FullIO>() -> impl for<'a> Pipeline<
 }
 
 #[must_use]
-pub(crate) fn typed_ast_pipeline<IO: FullIO>() -> impl for<'a> Pipeline<
-    (&'a ProgramInformation, &'a mut SourceMap<IO>),
+pub(crate) fn typed_ast_pipeline<IO: FullIO, T: LoadBinaryProgramInformation>()
+-> impl for<'a> Pipeline<
+    (&'a T, &'a mut SourceMap<IO>),
     Diagnostic,
     Output = (AST<TypedAST>, &'a mut SourceMap<IO>),
 > {
@@ -64,8 +65,8 @@ pub(crate) fn typed_ast_pipeline<IO: FullIO>() -> impl for<'a> Pipeline<
 }
 
 #[must_use]
-pub fn load_pipeline<IO: FullIO>() -> impl for<'a> Pipeline<
-    (&'a ProgramInformation, &'a mut SourceMap<IO>),
+pub fn load_pipeline<IO: FullIO, T: LoadInformation>() -> impl for<'a> Pipeline<
+    (&'a T, &'a mut SourceMap<IO>),
     Diagnostic,
     Output = (WasomeProgram, &'a mut SourceMap<IO>),
 > {

--- a/compiler/driver/src/program_information.rs
+++ b/compiler/driver/src/program_information.rs
@@ -1,84 +1,220 @@
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
-/// Information about a program being compiled
-///
-/// Intended to be passed to the parser driver to properly load and parse the program
-#[derive(Debug)]
-pub struct ProgramInformation {
+pub trait LoadInformation: Debug {
     /// The name of the program
-    name: String,
+    #[must_use]
+    fn name(&self) -> &str;
     /// The path of the program root
-    path: PathBuf,
+    #[must_use]
+    fn path(&self) -> &Path;
     /// All projects
     ///
     /// Including the main project and dependencies
-    projects: Vec<Project>,
+    #[must_use]
+    fn projects(&self) -> &[Project];
+}
+
+pub trait BinaryProgramInformation: Debug {
     /// The project of the main file
     ///
     /// A project with this name must exist in `projects`
-    main_project: String,
+    #[must_use]
+    fn main_file(&self) -> &Path;
     /// The main file
     ///
     /// Relative to the project root
     /// May not be empty
+    #[must_use]
+    fn main_project(&self) -> &str;
+}
+
+pub trait CompileInformation: Debug {
+    #[must_use]
+    fn opt_level(&self) -> OptLevel;
+}
+
+pub trait LoadBinaryProgramInformation: LoadInformation + BinaryProgramInformation {}
+impl<T: LoadInformation + BinaryProgramInformation> LoadBinaryProgramInformation for T {}
+
+pub trait FullProgramInformation: LoadBinaryProgramInformation + CompileInformation {}
+impl<T: LoadBinaryProgramInformation + CompileInformation> FullProgramInformation for T {}
+
+#[derive(Debug)]
+pub struct ConcreteLoadInformation {
+    name: String,
+    path: PathBuf,
+    projects: Vec<Project>,
+}
+
+impl ConcreteLoadInformation {
+    #[must_use]
+    pub fn new(name: String, path: PathBuf, projects: Vec<Project>) -> Self {
+        Self {
+            name,
+            path,
+            projects,
+        }
+    }
+}
+
+impl LoadInformation for ConcreteLoadInformation {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn projects(&self) -> &[Project] {
+        &self.projects
+    }
+}
+
+#[derive(Debug)]
+pub struct ConcreteBinaryProgramInformation {
+    main_project: String,
     main_file: PathBuf,
 }
 
-impl ProgramInformation {
+impl ConcreteBinaryProgramInformation {
+    pub fn new(main_project: String, main_file: PathBuf) -> Self {
+        Self {
+            main_project,
+            main_file,
+        }
+    }
+}
+impl BinaryProgramInformation for ConcreteBinaryProgramInformation {
+    fn main_file(&self) -> &Path {
+        &self.main_file
+    }
+
+    fn main_project(&self) -> &str {
+        &self.main_project
+    }
+}
+
+#[derive(Debug)]
+pub struct ConcreteCompileInformation {
+    opt_level: OptLevel,
+}
+
+impl ConcreteCompileInformation {
+    pub fn new(opt_level: OptLevel) -> Self {
+        Self { opt_level }
+    }
+}
+impl CompileInformation for ConcreteCompileInformation {
+    fn opt_level(&self) -> OptLevel {
+        self.opt_level
+    }
+}
+
+#[derive(Debug)]
+pub struct ConcreteLoadBinaryProgramInformation {
+    load: ConcreteLoadInformation,
+    binary: ConcreteBinaryProgramInformation,
+}
+
+impl ConcreteLoadBinaryProgramInformation {
     /// Tries to create a new instance
     ///
     /// # Errors
     ///
     /// - `main_file` is empty
     /// - `main_project` is not in `projects`
-    #[must_use]
     pub fn new(
-        name: String,
-        path: PathBuf,
-        projects: Vec<Project>,
-        main_project: String,
-        main_file: PathBuf,
+        load: ConcreteLoadInformation,
+        binary: ConcreteBinaryProgramInformation,
     ) -> Option<Self> {
-        let main_file_empty = main_file.iter().count() == 0;
-        let main_project_not_found = !projects
+        let main_file_empty = binary.main_file().iter().count() == 0;
+        let main_project_not_found = !load
+            .projects()
             .iter()
-            .any(|project| project.name() == main_project);
+            .any(|project| project.name() == binary.main_project());
         if main_file_empty || main_project_not_found {
             None
         } else {
-            Some(Self {
-                name,
-                path,
-                projects,
-                main_project,
-                main_file,
-            })
+            Some(Self { load, binary })
         }
     }
+}
 
-    #[must_use]
-    pub fn name(&self) -> &str {
-        &self.name
+impl LoadInformation for ConcreteLoadBinaryProgramInformation {
+    fn name(&self) -> &str {
+        self.load.name()
     }
 
-    #[must_use]
-    pub fn path(&self) -> &Path {
-        &self.path
+    fn path(&self) -> &Path {
+        self.load.path()
     }
 
-    #[must_use]
-    pub fn projects(&self) -> &[Project] {
-        &self.projects
+    fn projects(&self) -> &[Project] {
+        self.load.projects()
+    }
+}
+
+impl BinaryProgramInformation for ConcreteLoadBinaryProgramInformation {
+    fn main_file(&self) -> &Path {
+        self.binary.main_file()
     }
 
+    fn main_project(&self) -> &str {
+        self.binary.main_project()
+    }
+}
+
+/// Information about a program being compiled
+///
+/// Intended to be passed to the parser driver to properly load and parse the program
+#[derive(Debug)]
+pub struct ProgramInformation {
+    load_binary: ConcreteLoadBinaryProgramInformation,
+    compile: ConcreteCompileInformation,
+}
+
+impl ProgramInformation {
     #[must_use]
-    pub fn main_file(&self) -> &Path {
-        &self.main_file
+    pub fn new(
+        load_binary: ConcreteLoadBinaryProgramInformation,
+        compile: ConcreteCompileInformation,
+    ) -> Self {
+        Self {
+            load_binary,
+            compile,
+        }
+    }
+}
+
+impl LoadInformation for ProgramInformation {
+    fn name(&self) -> &str {
+        self.load_binary.name()
     }
 
-    #[must_use]
-    pub fn main_project(&self) -> &str {
-        &self.main_project
+    fn path(&self) -> &Path {
+        self.load_binary.path()
+    }
+
+    fn projects(&self) -> &[Project] {
+        self.load_binary.projects()
+    }
+}
+
+impl BinaryProgramInformation for ProgramInformation {
+    fn main_file(&self) -> &Path {
+        self.load_binary.main_file()
+    }
+
+    fn main_project(&self) -> &str {
+        self.load_binary.main_project()
+    }
+}
+
+impl CompileInformation for ProgramInformation {
+    fn opt_level(&self) -> OptLevel {
+        self.compile.opt_level()
     }
 }
 
@@ -108,4 +244,20 @@ impl Project {
     pub fn path(&self) -> &Path {
         &self.path
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OptLevel {
+    // -O0: No optimization. Fastest compile, best for debugging
+    O0,
+    // -O1: Basic optimizations. Good for speeding up test runs
+    O1,
+    // -O2: Standard release. Fast execution, reasonable compile time
+    O2,
+    // -O3: Max speed. Aggressive inlining/unrolling. Can bloat binary
+    O3,
+    // -Os: Optimize for size. Like O2, but restricts code bloat
+    Os,
+    // -Oz: Minimum size at all costs. Disables unrolling
+    Oz,
 }

--- a/compiler/driver/src/program_information.rs
+++ b/compiler/driver/src/program_information.rs
@@ -16,15 +16,16 @@ pub trait LoadInformation: Debug {
 }
 
 pub trait BinaryProgramInformation: Debug {
-    /// The project of the main file
-    ///
-    /// A project with this name must exist in `projects`
-    #[must_use]
-    fn main_file(&self) -> &Path;
     /// The main file
     ///
     /// Relative to the project root
     /// May not be empty
+    #[must_use]
+    fn main_file(&self) -> &Path;
+
+    /// The project of the main file
+    ///
+    /// A project with this name must exist in `projects`
     #[must_use]
     fn main_project(&self) -> &str;
 }

--- a/compiler/driver/src/source_collector.rs
+++ b/compiler/driver/src/source_collector.rs
@@ -1,4 +1,4 @@
-use crate::program_information::ProgramInformation;
+use crate::program_information::LoadInformation;
 use crate::source_element::{
     WasomeProgram, WasomeSourceDirectory, WasomeSourceElementLocation, WasomeSourceFile,
 };
@@ -29,7 +29,7 @@ const WASOME_FILE_ENDINGS: &[&str] = &[".waso", ".✨"];
 ///
 /// IO Errors may occur during the collection process
 pub fn collect_program(
-    to_collect: &ProgramInformation,
+    to_collect: &impl LoadInformation,
     load_from: &mut SourceMap<impl FullIO>,
 ) -> Result<WasomeProgram, CollectionError> {
     Ok(WasomeProgram::new(

--- a/compiler/driver/tests/integration_tests.rs
+++ b/compiler/driver/tests/integration_tests.rs
@@ -1,6 +1,9 @@
 use ast::symbol::SymbolWithTypeParameter;
 use driver::parser_driver::generate_untyped_ast;
-use driver::program_information::{ProgramInformation, Project};
+use driver::program_information::{
+    ConcreteBinaryProgramInformation, ConcreteLoadBinaryProgramInformation,
+    ConcreteLoadInformation, ProgramInformation, Project,
+};
 use driver::source_collector::collect_program;
 use driver::syntax_check;
 use io::WasomeLoader;
@@ -51,12 +54,13 @@ fn test_simple_program() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "simple".to_string(),
-        root.clone(),
-        vec![Project::new("simple".to_string(), PathBuf::from("simple"))],
-        "simple".to_string(),
-        main_file,
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "simple".to_string(),
+            root.clone(),
+            vec![Project::new("simple".to_string(), PathBuf::from("simple"))],
+        ),
+        ConcreteBinaryProgramInformation::new("simple".to_string(), main_file),
     )
     .unwrap();
 
@@ -88,15 +92,16 @@ fn test_multi_module_program() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_module".to_string(),
-        root.clone(),
-        vec![Project::new(
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
             "multi_module".to_string(),
-            PathBuf::from("multi_module"),
-        )],
-        "multi_module".to_string(),
-        main_file,
+            root.clone(),
+            vec![Project::new(
+                "multi_module".to_string(),
+                PathBuf::from("multi_module"),
+            )],
+        ),
+        ConcreteBinaryProgramInformation::new("multi_module".to_string(), main_file),
     )
     .unwrap();
 
@@ -143,15 +148,16 @@ fn test_multi_project_program() {
     let root = dir.path().to_path_buf().join("multi_project");
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_project".to_string(),
-        root.clone(),
-        vec![
-            Project::new("app".to_string(), PathBuf::from("app")),
-            Project::new("lib".to_string(), PathBuf::from("lib")),
-        ],
-        "app".to_string(),
-        main_file,
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "multi_project".to_string(),
+            root.clone(),
+            vec![
+                Project::new("app".to_string(), PathBuf::from("app")),
+                Project::new("lib".to_string(), PathBuf::from("lib")),
+            ],
+        ),
+        ConcreteBinaryProgramInformation::new("app".to_string(), main_file),
     )
     .unwrap();
 
@@ -199,15 +205,16 @@ fn test_empty_import_program() {
     let root = dir.path().to_path_buf().join("empty_import");
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "empty_import".to_string(),
-        root.clone(),
-        vec![
-            Project::new("app".to_string(), PathBuf::from("app")),
-            Project::new("lib".to_string(), PathBuf::from("lib")),
-        ],
-        "app".to_string(),
-        main_file,
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "empty_import".to_string(),
+            root.clone(),
+            vec![
+                Project::new("app".to_string(), PathBuf::from("app")),
+                Project::new("lib".to_string(), PathBuf::from("lib")),
+            ],
+        ),
+        ConcreteBinaryProgramInformation::new("app".to_string(), main_file),
     )
     .unwrap();
 
@@ -240,15 +247,16 @@ fn test_circular_imports() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("a/a.waso");
 
-    let prog_info = ProgramInformation::new(
-        "circular".to_string(),
-        root.clone(),
-        vec![Project::new(
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
             "circular".to_string(),
-            PathBuf::from("circular"),
-        )],
-        "circular".to_string(),
-        main_file,
+            root.clone(),
+            vec![Project::new(
+                "circular".to_string(),
+                PathBuf::from("circular"),
+            )],
+        ),
+        ConcreteBinaryProgramInformation::new("circular".to_string(), main_file),
     )
     .unwrap();
 
@@ -291,12 +299,13 @@ fn test_syntax_check_simple() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "simple".to_string(),
-        root.clone(),
-        vec![Project::new("simple".to_string(), PathBuf::from("simple"))],
-        "simple".to_string(),
-        main_file,
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "simple".to_string(),
+            root.clone(),
+            vec![Project::new("simple".to_string(), PathBuf::from("simple"))],
+        ),
+        ConcreteBinaryProgramInformation::new("simple".to_string(), main_file),
     )
     .unwrap();
 
@@ -315,15 +324,16 @@ fn test_syntax_check_multi_module() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_module".to_string(),
-        root.clone(),
-        vec![Project::new(
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
             "multi_module".to_string(),
-            PathBuf::from("multi_module"),
-        )],
-        "multi_module".to_string(),
-        main_file,
+            root.clone(),
+            vec![Project::new(
+                "multi_module".to_string(),
+                PathBuf::from("multi_module"),
+            )],
+        ),
+        ConcreteBinaryProgramInformation::new("multi_module".to_string(), main_file),
     )
     .unwrap();
 
@@ -341,15 +351,16 @@ fn test_syntax_check_multi_project() {
     let root = dir.path().to_path_buf().join("multi_project");
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_project".to_string(),
-        root.clone(),
-        vec![
-            Project::new("app".to_string(), PathBuf::from("app")),
-            Project::new("lib".to_string(), PathBuf::from("lib")),
-        ],
-        "app".to_string(),
-        main_file,
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "multi_project".to_string(),
+            root.clone(),
+            vec![
+                Project::new("app".to_string(), PathBuf::from("app")),
+                Project::new("lib".to_string(), PathBuf::from("lib")),
+            ],
+        ),
+        ConcreteBinaryProgramInformation::new("app".to_string(), main_file),
     )
     .unwrap();
 
@@ -367,15 +378,16 @@ fn test_syntax_check_circular() {
     let root = dir.path().to_path_buf();
     let main_file = PathBuf::from("a/a.waso");
 
-    let prog_info = ProgramInformation::new(
-        "circular".to_string(),
-        root.clone(),
-        vec![Project::new(
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
             "circular".to_string(),
-            PathBuf::from("circular"),
-        )],
-        "circular".to_string(),
-        main_file,
+            root.clone(),
+            vec![Project::new(
+                "circular".to_string(),
+                PathBuf::from("circular"),
+            )],
+        ),
+        ConcreteBinaryProgramInformation::new("circular".to_string(), main_file),
     )
     .unwrap();
 

--- a/compiler/middle_end/semantic_analyzer/tests/error_tests.rs
+++ b/compiler/middle_end/semantic_analyzer/tests/error_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use tempfile::TempDir;
 
     use driver::parser_driver::generate_untyped_ast;
-    use driver::program_information::{ProgramInformation, Project};
+    use driver::program_information::{ConcreteBinaryProgramInformation, ConcreteLoadBinaryProgramInformation, ConcreteLoadInformation, Project};
     use driver::source_collector::collect_program;
     use io::WasomeLoader;
     use semantic_analyzer::analyze;
@@ -31,14 +31,17 @@ mod tests {
         let root = dir.path().to_path_buf().join("error_project");
         let main_file = PathBuf::from("main.waso");
 
-        let prog_info = ProgramInformation::new(
-            "error_project".to_string(),
-            root.clone(),
-            vec![Project::new("app".to_string(), PathBuf::from("app"))],
-            "app".to_string(),
-            main_file,
-        )
-        .expect("Failed to create ProgramInformation");
+        let prog_info = ConcreteLoadBinaryProgramInformation::new(
+            ConcreteLoadInformation::new(
+                "error_project".to_string(),
+                root.clone(),
+                vec![
+                    Project::new("app".to_string(), PathBuf::from("app")),
+                ]),
+            ConcreteBinaryProgramInformation::new(
+                "app".to_string(),
+                main_file)
+        ).expect("Failed to create ProgramInformation");
 
         let mut source_map = SourceMap::<WasomeLoader>::with_default(root);
 
@@ -73,14 +76,17 @@ mod tests {
         let root = dir.path().to_path_buf().join("error_project");
         let main_file = PathBuf::from("main.waso");
 
-        let prog_info = ProgramInformation::new(
-            "error_project".to_string(),
-            root.clone(),
-            vec![Project::new("app".to_string(), PathBuf::from("app"))],
-            "app".to_string(),
-            main_file,
-        )
-        .expect("Failed to create ProgramInformation");
+        let prog_info = ConcreteLoadBinaryProgramInformation::new(
+            ConcreteLoadInformation::new(
+                "error_project".to_string(),
+                root.clone(),
+                vec![
+                    Project::new("app".to_string(), PathBuf::from("app")),
+                ]),
+            ConcreteBinaryProgramInformation::new(
+                "app".to_string(),
+                main_file)
+        ).expect("Failed to create ProgramInformation");
 
         let mut source_map = SourceMap::<WasomeLoader>::with_default(root);
         let untyped_ast = generate_untyped_ast(

--- a/compiler/middle_end/semantic_analyzer/tests/integration_tests.rs
+++ b/compiler/middle_end/semantic_analyzer/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use ast::type_parameter::TypedTypeParameter;
 use ast::visibility::Visibility;
 use ast::{ASTNode, SemanticEq, TypedAST, AST};
 use driver::parser_driver::generate_untyped_ast;
-use driver::program_information::{ProgramInformation, Project};
+use driver::program_information::{ConcreteBinaryProgramInformation, ConcreteLoadBinaryProgramInformation, ConcreteLoadInformation, Project};
 use driver::source_collector::collect_program;
 use io::WasomeLoader;
 use semantic_analyzer::analyze;
@@ -66,17 +66,18 @@ fn test_multi_project_program() {
     let root = dir.path().to_path_buf().join("multi_project");
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_project".to_string(),
-        root.clone(),
-        vec![
-            Project::new("app".to_string(), PathBuf::from("app")),
-            Project::new("lib".to_string(), PathBuf::from("lib")),
-        ],
-        "app".to_string(),
-        main_file,
-    )
-    .unwrap();
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "multi_project".to_string(),
+            root.clone(),
+            vec![
+                Project::new("app".to_string(), PathBuf::from("app")),
+                Project::new("lib".to_string(), PathBuf::from("lib")),
+            ]),
+        ConcreteBinaryProgramInformation::new(
+            "app".to_string(),
+            main_file)
+    ).unwrap();
 
     let mut sm = SourceMap::<WasomeLoader>::with_default(root);
 
@@ -198,17 +199,18 @@ fn test_multi_project_generics() {
     let root = dir.path().to_path_buf().join("multi_project_generics");
     let main_file = PathBuf::from("main.waso");
 
-    let prog_info = ProgramInformation::new(
-        "multi_project_generics".to_string(),
-        root.clone(),
-        vec![
-            Project::new("app".to_string(), PathBuf::from("app")),
-            Project::new("lib".to_string(), PathBuf::from("lib")),
-        ],
-        "app".to_string(),
-        main_file,
-    )
-    .unwrap();
+    let prog_info = ConcreteLoadBinaryProgramInformation::new(
+        ConcreteLoadInformation::new(
+            "multi_project_generics".to_string(),
+            root.clone(),
+            vec![
+                Project::new("app".to_string(), PathBuf::from("app")),
+                Project::new("lib".to_string(), PathBuf::from("lib")),
+            ]),
+        ConcreteBinaryProgramInformation::new(
+            "app".to_string(),
+            main_file)
+    ).unwrap();
 
     let mut sm = SourceMap::<WasomeLoader>::with_default(root);
     let ast = generate_untyped_ast(collect_program(&prog_info, &mut sm).unwrap(), &mut sm)


### PR DESCRIPTION
This splits up ProgramInformation

For the new CompileInformation, only the OptLevel is included. Should anything else need to be required later, it will have to be added.