### PR TITLE
Improved external function mangling

### DIFF
--- a/compiler/codegen/src/generators/expression.rs
+++ b/compiler/codegen/src/generators/expression.rs
@@ -514,10 +514,17 @@ impl<'ctx, 'fc> Codegen<'ctx> {
         let lhs_bit_width = lhs_int.get_type().get_bit_width();
         // Get a llvm value of the bit length
         // The data type should be the one of rhs as we compare rhs with it
-        let lhs_bit_width_val = rhs_int.get_type().const_int(u64::from(lhs_bit_width), false);
+        let lhs_bit_width_val = rhs_int
+            .get_type()
+            .const_int(u64::from(lhs_bit_width), false);
         let is_invalid = llvm_context
             .builder()
-            .build_int_compare(IntPredicate::UGE, rhs_int, lhs_bit_width_val, "shift_overflow")
+            .build_int_compare(
+                IntPredicate::UGE,
+                rhs_int,
+                lhs_bit_width_val,
+                "shift_overflow",
+            )
             .unwrap();
         let then_block = llvm_context.context().append_basic_block(
             statement_context.function_context().current_function(),

--- a/compiler/codegen/src/generators/function.rs
+++ b/compiler/codegen/src/generators/function.rs
@@ -45,7 +45,10 @@ impl<'ctx> Codegen<'ctx> {
                 .build_alloca(llvm_context.lower_type(param_ast.data_type()), name)
                 .unwrap();
 
-            llvm_context.builder().build_store(var, param_llvm_value).unwrap();
+            llvm_context
+                .builder()
+                .build_store(var, param_llvm_value)
+                .unwrap();
 
             vars.insert(param_ast, var);
         }

--- a/compiler/codegen/src/generators/mod.rs
+++ b/compiler/codegen/src/generators/mod.rs
@@ -5,7 +5,7 @@ mod statement;
 use crate::context::{FunctionContext, StatementContext};
 use crate::symbols::{EnumInformation, StructInformation, VariableTable};
 use crate::{Codegen, context::LLVMContext};
-use ast::data_type::Typed;
+use ast::data_type::{DataType, Typed};
 use ast::expression::FunctionCall;
 use ast::id::Id;
 use ast::symbol::SymbolWithTypeParameter;
@@ -16,6 +16,7 @@ use ast::traversal::enum_traversal::EnumTraversalHelper;
 use ast::traversal::file_traversal::FileTraversalHelper;
 use ast::traversal::function_traversal::FunctionTraversalHelper;
 use ast::traversal::struct_traversal::StructTraversalHelper;
+use ast::type_parameter::TypedTypeParameter;
 use ast::{AST, TypedAST};
 use inkwell::types::BasicType;
 use inkwell::values::CallSiteValue;
@@ -274,7 +275,9 @@ impl<'ctx> Codegen<'ctx> {
                         .map(|field| llvm_context.lower_type(field.inner().data_type())),
                 )
                 .collect::<Vec<_>>();
-            struct_information.lowered().set_body(&fields_lowered, false);
+            struct_information
+                .lowered()
+                .set_body(&fields_lowered, false);
             for field in fields {
                 struct_information.add_field(field.inner_owned());
             }
@@ -320,11 +323,17 @@ impl<'ctx> Codegen<'ctx> {
                 match func.inner().function_type() {
                     FunctionType::Regular(_) => mangle(symbol.name(), symbol.id()),
                     FunctionType::External => {
-                        let sizes = symbol
-                            .params()
+                        let containing_struct = func.containing_struct();
+                        let data_types = containing_struct
                             .iter()
-                            .map(|param| param.data_type().size_bytes())
-                            .map(|param| param.to_string())
+                            .flat_map(|st| st.type_parameters().iter())
+                            .chain(symbol.type_parameters().iter())
+                            .map(TypedTypeParameter::data_type);
+                        let sizes = data_types
+                            .map(|param| match param {
+                                DataType::Struct(_) | DataType::Enum(_) => "prt".to_string(),
+                                _ => param.size_bytes().to_string(),
+                            })
                             .collect::<Vec<_>>()
                             .join("_");
                         if sizes.is_empty() {
@@ -339,8 +348,9 @@ impl<'ctx> Codegen<'ctx> {
             // as the mangling for them does not always produce unique names
             // In this case, we just take the already existing signature as we never implement them
             // and won't get conflicts there
-            let lowered = module.get_function(&name).unwrap_or_else(||
-                module.add_function(&name, lowered_type, None));
+            let lowered = module
+                .get_function(&name)
+                .unwrap_or_else(|| module.add_function(&name, lowered_type, None));
             debug_assert!(
                 llvm_context
                     .type_registry_mut()

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -6,16 +6,24 @@ mod memory;
 mod symbols;
 mod types;
 
-use ast::{TypedAST, AST};
 use ast::symbol::FunctionSymbol;
+use ast::{AST, TypedAST};
 use bon::bon;
 use inkwell::context::Context;
 use std::rc::Rc;
 pub use types::OptLevel;
 
-pub fn codegen(opt_level: OptLevel, main_function: Rc<FunctionSymbol<TypedAST>>, to_generate: AST<TypedAST>) -> Result<Vec<u8>, CodegenCreationError> {
+pub fn codegen(
+    opt_level: OptLevel,
+    main_function: Rc<FunctionSymbol<TypedAST>>,
+    to_generate: AST<TypedAST>,
+) -> Result<Vec<u8>, CodegenCreationError> {
     let context = Context::create();
-    let mut codegen = Codegen::builder().opt_level(opt_level).main_function(main_function).context(&context).build()?;
+    let mut codegen = Codegen::builder()
+        .opt_level(opt_level)
+        .main_function(main_function)
+        .context(&context)
+        .build()?;
     Ok(codegen.compile(&to_generate))
 }
 /// Top-level code generator that orchestrates compilation of a typed AST to WebAssembly object code.


### PR DESCRIPTION
# Current Status

External functions roughly use the following mangling system:
<Function name>_<Size of each parameter>

This approach has two problems:
1. It is unknown what is a pointer and what not. So reference counting can not be done on the implementing rust side.
2. Return type sizes are not included. This is problematic when the return type is a type parameter.

# Changes

Now, the type parameters are used instead of the parameters. Also, pointers now use ptr instead of their size.


cargo fmt changed a bit in other files, I am leaving that in.