### PR TITLE
Fixed chained struct field access

### DIFF
--- a/compiler/middle_end/parser/src/expression_parser.rs
+++ b/compiler/middle_end/parser/src/expression_parser.rs
@@ -184,19 +184,21 @@ pub fn expression_parser<'src>()
                 )
             });
 
-        let sfa =
-            base.clone()
-                .then_ignore(token_parser(TokenType::Dot))
-                .then(identifier_parser())
-                .map(|(struct_expr, field)| {
-                    let pos = struct_expr.position().merge(field.span.into()).unwrap();
-                    ASTNode::new(
-                        Expression::StructFieldAccess(Box::new(
-                            StructFieldAccess::<UntypedAST>::new(struct_expr, field.inner),
-                        )),
-                        pos,
-                    )
-                });
+        let sfa = base.clone().foldl(
+            token_parser(TokenType::Dot)
+                .ignore_then(identifier_parser())
+                .repeated(),
+            |struct_expr, field| {
+                let pos = struct_expr.position().merge(field.span.into()).unwrap();
+                ASTNode::new(
+                    Expression::StructFieldAccess(Box::new(StructFieldAccess::<UntypedAST>::new(
+                        struct_expr,
+                        field.inner,
+                    ))),
+                    pos,
+                )
+            },
+        );
 
         let simple_combined = choice((method_call, sfa, base));
 

--- a/compiler/middle_end/parser/src/statement_parser.rs
+++ b/compiler/middle_end/parser/src/statement_parser.rs
@@ -5,7 +5,7 @@ use crate::misc_parsers::{
     datatype_parser, identifier_parser, identifier_with_type_parameter_parser,
     maybe_statement_separator, statement_separator, token_parser,
 };
-use crate::{map, unspan_vec, ParserSpan};
+use crate::{ParserSpan, map, unspan_vec};
 use ast::statement::{
     CodeBlock, Conditional, ControlStructure, IfEnumVariant, Loop, LoopType, Return, Statement,
     StructFieldAssignment, VariableAssignment, VariableDeclaration,
@@ -58,35 +58,38 @@ pub fn statement_parser<'src>()
         let not_dot = token_parser(TokenType::Dot).not();
         let not_assign_token = any().spanned().and_is(not_assign.clone());
 
-        let struct_field_assignment =
-        expression_parser().nested_in(
-            not_assign_token
-                .clone()
-                .then_ignore(
-                    // Don't consume the struct field in the expression
-                    not_assign_token
-                        .clone()
-                        .and_is(not_dot)
-                        .repeated()
-                        .then(token_parser(TokenType::Dot))
-                        .rewind(),
-                )
-                .repeated()
-                .at_least(1)
-                .to_slice())
+        let struct_field_assignment = expression_parser()
+            .nested_in(
+                not_assign_token
+                    .clone()
+                    .then_ignore(
+                        // Don't consume the struct field in the expression
+                        not_assign_token
+                            .clone()
+                            .and_is(not_dot)
+                            .repeated()
+                            .then(token_parser(TokenType::Dot))
+                            .rewind(),
+                    )
+                    .repeated()
+                    .at_least(1)
+                    .to_slice(),
+            )
             .then_ignore(token_parser(TokenType::Dot))
             .then(
                 // Identifiers can never contain assignments
                 // So this never consumes the assignment token
-                identifier_parser()
+                identifier_parser(),
             )
             .then_ignore(token_parser(TokenType::Assign))
             .then(expression.clone())
             .map(|((src, field), val)| {
                 let pos: ParserSpan = src.position().merge(*val.position()).unwrap().into();
-                pos.make_wrapped(
-                    StructFieldAssignment::<UntypedAST>::new(src, field.inner, val)
-                )
+                pos.make_wrapped(StructFieldAssignment::<UntypedAST>::new(
+                    src,
+                    field.inner,
+                    val,
+                ))
             });
 
         let variable_declaration = data_type

--- a/compiler/middle_end/parser/tests/integration_tests.rs
+++ b/compiler/middle_end/parser/tests/integration_tests.rs
@@ -10,9 +10,10 @@ use ast::statement::{
 };
 use ast::symbol::{
     EnumSymbol, EnumVariantSymbol, FunctionSymbol, ModuleUsageNameSymbol, StructFieldSymbol,
-    StructSymbol, VariableSymbol,
+    StructSymbol, UntypedTypeParameterSymbol, VariableSymbol,
 };
 use ast::top_level::{Function, FunctionType, Import, ImportRoot};
+use ast::type_parameter::UntypedTypeParameter;
 use ast::visibility::Visibility;
 use ast::{ASTNode, SemanticEq, UntypedAST};
 use parser::{FileInformation, parse};
@@ -85,6 +86,8 @@ const SUBDIR_IMPORT_MAIN: &'static str =
     include_str!("test_programs/single_project/subdir_import/main.waso");
 const SUBDIR_IMPORT_MATH: &'static str =
     include_str!("test_programs/single_project/subdir_import/math/main.waso");
+const NESTED_STRUCT_FIELD_ACCESS: &'static str =
+    include_str!("test_programs/single_file/nexted_struct_field_access.waso");
 
 #[test]
 fn test_parse_generics() {
@@ -2589,5 +2592,109 @@ fn test_parse_subdir_import() {
         Vec::new(),
     );
 
+    assert!(parsed.semantic_eq(&expected));
+}
+
+#[test]
+fn test_parse_nested_struct_field_access() {
+    let (sm, id) = setup_source_map(NESTED_STRUCT_FIELD_ACCESS);
+    let to_parse = FileInformation::new(id, "test", &sm).unwrap();
+    let parsed = parse(&to_parse).expect("Parsing failed");
+
+    let t_tp = UntypedTypeParameter::new(Rc::new(UntypedTypeParameterSymbol::new("T".to_string())));
+    let struct_symbol = Rc::new(StructSymbol::new("Box".to_string(), vec![t_tp]));
+    let inner_field = wrap(StructField::new(
+        Rc::new(StructFieldSymbol::new(
+            "inner".to_string(),
+            UntypedDataType::new("T".to_string(), Vec::new()),
+        )),
+        Visibility::Public,
+    ));
+
+    let point_struct = wrap(Struct::new(
+        struct_symbol.clone(),
+        Vec::new(),
+        vec![inner_field],
+        Visibility::Private,
+    ));
+
+    let main_symbol = Rc::new(FunctionSymbol::new(
+        "main".to_string(),
+        None,
+        vec![],
+        Vec::new(),
+    ));
+
+    // Box[Box[char]] box <- new Box[Box[char]] { inner <- new Box[char] { inner <- 'X' } }
+    let box_var = Rc::new(VariableSymbol::new(
+        "box".to_string(),
+        UntypedDataType::new(
+            "Box".to_string(),
+            vec![UntypedDataType::new(
+                "Box".to_string(),
+                vec![UntypedDataType::new("char".to_string(), vec![])],
+            )],
+        ),
+    ));
+    let new_box_expr = wrap(Expression::NewStruct(Box::new(
+        NewStruct::<UntypedAST>::new(
+            (
+                "Box".to_string(),
+                vec![UntypedDataType::new(
+                    "Box".to_string(),
+                    vec![UntypedDataType::new("char".to_string(), vec![])],
+                )],
+            ),
+            vec![(
+                wrap("inner".to_string()),
+                wrap(Expression::NewStruct(Box::new(
+                    NewStruct::<UntypedAST>::new(
+                        (
+                            "Box".to_string(),
+                            vec![UntypedDataType::new("char".to_string(), vec![])],
+                        ),
+                        vec![(
+                            wrap("inner".to_string()),
+                            wrap(Expression::Literal("\'X\'".to_string())),
+                        )],
+                    ),
+                ))),
+            )],
+        ),
+    )));
+    let stmt1 = wrap(Statement::VariableDeclaration(VariableDeclaration::<
+        UntypedAST,
+    >::new(
+        box_var.clone(),
+        new_box_expr,
+    )));
+
+    // box.inner.inner
+    let first_sfa = wrap(Expression::StructFieldAccess(Box::new(
+        StructFieldAccess::<UntypedAST>::new(
+            wrap(Expression::Variable("box".to_string())),
+            "inner".to_string(),
+        ),
+    )));
+    let second_sfa = wrap(Expression::StructFieldAccess(Box::new(
+        StructFieldAccess::<UntypedAST>::new(first_sfa, "inner".to_string()),
+    )));
+
+    let stmt2 = wrap(Statement::Expression(second_sfa));
+
+    let main_body = wrap(Statement::Codeblock(CodeBlock::new(vec![stmt1, stmt2])));
+    let main_func = wrap(Function::new(
+        main_symbol,
+        FunctionType::Regular(main_body),
+        Visibility::Private,
+    ));
+
+    let expected = ast::file::File::new(
+        "main".to_string(),
+        Vec::new(),
+        vec![main_func],
+        Vec::new(),
+        vec![point_struct],
+    );
     assert!(parsed.semantic_eq(&expected));
 }

--- a/docs/examples/single_file/nexted_struct_field_access.waso
+++ b/docs/examples/single_file/nexted_struct_field_access.waso
@@ -1,0 +1,10 @@
+struct Box[T] {
+    pub T inner
+}
+
+fn main() {
+
+    Box[Box[char]] box <- new Box[Box[char]] { inner <- new Box[char] { inner <- 'X' } }
+
+    box.inner.inner
+}


### PR DESCRIPTION
# Current state

Chained struct field accesses are syntax errors.
e.g.:
`box.inner.inner` does not parse.

# Expected behavior

They do compile just fine.

# Changes

The parser was patched to use fold_l to parse them properly.

A test for this is also included.

cargo fmt also made some changes.