### PR TITLE
Improved stdlib error when enabling neither web or runtime

### DIFF
--- a/stdlib/rust/src/plattform.rs
+++ b/stdlib/rust/src/plattform.rs
@@ -10,3 +10,6 @@ pub use web::*;
 
 #[cfg(all(feature = "runtime", feature = "web"))]
 compile_error!("Can't both target the runtime and web at the same time!");
+
+#[cfg(not(any(feature = "runtime", feature = "web")))]
+compile_error!("You must either enable the `runtime` or `web` feature!");


### PR DESCRIPTION
New error:
```

error: You must either enable the `runtime` or `web` feature!
  --> src/plattform.rs:15:1
   |
15 | compile_error!("You must either enable the `runtime` or `web` feature!");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ```