### PR TITLE
Fix wrong string_push_f64 data type

### DIFF
--- a/stdlib/wasome/src/lib.waso
+++ b/stdlib/wasome/src/lib.waso
@@ -55,7 +55,7 @@ extern fn string_push_char(String string, char to_push)
 extern fn string_push_s32(String string, s32 to_push)
 extern fn string_push_s64(String string, s64 to_push)
 extern fn string_push_u64(String string, u64 to_push)
-extern fn string_push_f64(String string, s64 to_push)
+extern fn string_push_f64(String string, f64 to_push)
 extern fn string_push_string(String string, String to_push)
 extern fn string_pop(String string) -> char
 extern fn string_drop(String string)
@@ -77,7 +77,7 @@ pub struct String {
     pub fn push_u64(u64 to_push) {
         string_push_u64(self, to_push)
     }
-    pub fn push_f64(s64 to_push) {
+    pub fn push_f64(f64 to_push) {
         string_push_f64(self, to_push)
     }
     pub fn push_string(String to_push) {


### PR DESCRIPTION
Turned 
`extern fn string_push_f64(String string, s64 to_push)`
into
`extern fn string_push_f64(String string, f64 to_push)`