### PR TITLE
Fix host environment clash for HOST_WASOME_DIR in Docker Compose

### DIFF
--- a/website/docker-compose.yml
+++ b/website/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     expose:
       - "3000"
     environment:
-      - HOST_WASOME_DIR=${HOST_WASOME_DIR:-website_wasome-compiler-cache}
+      - HOST_WASOME_DIR=${WASOME_COMPILER_VOLUME:-website_wasome-compiler-cache}
       - WASOME_HOME=/opt/wasome
       - DOCKER_RUNTIME=${DOCKER_RUNTIME:-runsc}
       - TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY:-}


### PR DESCRIPTION
This pull request resolves a critical OCI runtime start failure that occurs when deploying the compilation sandbox on a host that already has HOST_WASOME_DIR configured in its environment.

Why the failure happened:
The docker-compose setup allowed overriding HOST_WASOME_DIR via environment variable substitution. If the host has HOST_WASOME_DIR set to /root/.wasome, Docker Compose mounted that directory path instead of the correct cache volume name. Since /root/ directories are restricted to root on the host, gVisor's restricted file proxy process was blocked from reading the binary file, causing the container initialization to crash.

What this fix does:
Renames the environment override variable inside website/docker-compose.yml to WASOME_COMPILER_VOLUME to break the name conflict, ensuring it correctly falls back to the default website_wasome-compiler-cache volume.